### PR TITLE
В хуках для git должен использоваться разделитель строк LF

### DIFF
--- a/src/Классы/КомандаИнсталл.os
+++ b/src/Классы/КомандаИнсталл.os
@@ -107,7 +107,7 @@
 	Лог.Отладка("Создание файла pre-commit hook для %1", КаталогРепозитория);
 	ТекстPrecommtHook = Новый ТекстовыйДокумент;
 	ТекстPrecommtHook.УстановитьТекст(КомандаPrecommtHook);
-	ТекстPrecommtHook.Записать(ФайлPrecommtHook, КодировкаТекста.UTF8NoBOM);
+	ТекстPrecommtHook.Записать(ФайлPrecommtHook, КодировкаТекста.UTF8NoBOM, Символы.ПС);
 
 	Лог.Информация("Pre-commit hook для %1 создан", КаталогРепозитория);
 


### PR DESCRIPTION
По-умолчанию ТекстовыйДокумент.Записать() запысывает хук-файл pre-commit с разделителем строк CR+LF.
Из-за этого хук не работает в Debian Linux Jessie (git 2.1.4).
Выдаёт ошибку при коммите:
error: cannot run .git/hooks/pre-commit: No such file or directory

В windows работают оба варианта (LF и CR+LF), кроме того, если создать в windows (с помощью официального консольного git) новый репозиторий, то в каталоге .git/hooks лежат примеры хуков и у них разделитель LF.