### PR TITLE
Update СинхронизацияОбъектовМетаданныхИФайлов.os

### DIFF
--- a/src/СценарииОбработки/СинхронизацияОбъектовМетаданныхИФайлов.os
+++ b/src/СценарииОбработки/СинхронизацияОбъектовМетаданныхИФайлов.os
@@ -250,6 +250,7 @@
 	Список.Добавить("SessionParameters", "SessionParameter");
 	Список.Добавить("SettingsStorages", "SettingsStorage");
 	Список.Добавить("StyleItems", "StyleItem");
+	Список.Добавить("Styles", "Style");
 	Список.Добавить("Subsystems", "Subsystem");
 	Список.Добавить("Tasks", "Task");
 	Список.Добавить("WebServices", "WebService");


### PR DESCRIPTION
Добавил отсутствующий Styles - причина отказа обработки коммита с исходниками конфигурации УНФ 1.6.9.32.